### PR TITLE
Fix Windows build

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,6 +1,7 @@
 ARG_ENABLE("lz4", "enable lz4 support", "no");
 
 if (PHP_LZ4 != "no") {
+   ADD_FLAG("CFLAGS_LZ4", " /I" + configure_module_dirname + " /I" + configure_module_dirname + "/lz4");
    EXTENSION("lz4", "lz4.c", PHP_LZ4_SHARED, "");
    ADD_SOURCES(configure_module_dirname + "/lz4/lib", "lz4.c lz4hc.c xxhash.c", "lz4");
    PHP_INSTALL_HEADERS("ext/lz4/", "php_lz4.h");


### PR DESCRIPTION
Windows build failed now, with the error messages that the build system could not find lz4.h. This commit adds the lz4 directory to the compiler flags.